### PR TITLE
Fix function name parsing and tidy docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ npm start
 
 ## Setup
 
-If you'd like to contribute a pull request, we highly recommend setting the pre-commit hooks which will run the formatter and linter before each git commit. This is a great way of catching issues early on without waiting to run the GitHub Actions for your pull requet.
+If you'd like to contribute a pull request, we highly recommend setting the pre-commit hooks which will run the formatter and linter before each git commit. This is a great way of catching issues early on without waiting to run the GitHub Actions for your pull request.
 
 Simply run this once in your repo:
 

--- a/src/__tests__/getFunctionNameFromPath.test.ts
+++ b/src/__tests__/getFunctionNameFromPath.test.ts
@@ -1,0 +1,16 @@
+import { getFunctionNameFromPath } from "@/ipc/processors/response_processor";
+import { describe, expect, it } from "vitest";
+
+describe("getFunctionNameFromPath", () => {
+  it("returns directory name for index files", () => {
+    expect(getFunctionNameFromPath("/foo/bar/index.ts")).toBe("bar");
+  });
+
+  it("returns file name when path points directly to a file", () => {
+    expect(getFunctionNameFromPath("foo.ts")).toBe("foo");
+  });
+
+  it("returns directory name when given a directory path", () => {
+    expect(getFunctionNameFromPath("/foo/bar")).toBe("bar");
+  });
+});

--- a/src/components/TelemetryBanner.tsx
+++ b/src/components/TelemetryBanner.tsx
@@ -9,9 +9,6 @@ const hideBannerAtom = atom(false);
 export function PrivacyBanner() {
   const [hideBanner, setHideBanner] = useAtom(hideBannerAtom);
   const { settings, updateSettings } = useSettings();
-  // TODO: Implement state management for banner visibility and user choice
-  // TODO: Implement functionality for Accept, Reject, Ask me later buttons
-  // TODO: Add state to hide/show banner based on user choice
   if (hideBanner) {
     return null;
   }

--- a/src/ipc/processors/response_processor.ts
+++ b/src/ipc/processors/response_processor.ts
@@ -38,8 +38,12 @@ interface Output {
   error: unknown;
 }
 
-function getFunctionNameFromPath(input: string): string {
-  return path.basename(path.extname(input) ? path.dirname(input) : input);
+export function getFunctionNameFromPath(input: string): string {
+  if (!path.extname(input)) {
+    return path.basename(input);
+  }
+  const base = path.basename(input, path.extname(input));
+  return base === "index" ? path.basename(path.dirname(input)) : base;
 }
 
 async function readFileFromFunctionPath(input: string): Promise<string> {


### PR DESCRIPTION
## Summary
- correct typo in contributor guide
- fix function name parsing for file paths
- remove outdated TelemetryBanner TODOs
- add tests for `getFunctionNameFromPath`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b32a9306d883319d950682d1797be5
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix function name parsing from file paths so we return the correct name in all cases. Also tidy docs and remove stale TelemetryBanner TODOs.

- **Bug Fixes**
  - getFunctionNameFromPath now handles files, index files, and directory paths correctly (e.g., "foo.ts" -> "foo", "/a/b/index.ts" -> "b", "/a/b" -> "b") and is exported. Added unit tests.

<!-- End of auto-generated description by cubic. -->

