### PR TITLE
feat: add background task skeleton

### DIFF
--- a/src/background/TaskDatabase.ts
+++ b/src/background/TaskDatabase.ts
@@ -1,0 +1,154 @@
+import Database from "better-sqlite3";
+import { BackgroundTask } from "./TaskTypes";
+
+/**
+ * Simple SQLite backed task database. It lazily creates tables if they do not
+ * yet exist. The database stores tasks and their dependencies.
+ */
+export class TaskDatabase {
+  private db: Database.Database;
+
+  constructor(path = ":memory:") {
+    this.db = new Database(path);
+    this.init();
+  }
+
+  private init() {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS background_tasks (
+        id TEXT PRIMARY KEY,
+        type TEXT NOT NULL,
+        title TEXT NOT NULL,
+        description TEXT,
+        priority INTEGER DEFAULT 3,
+        status TEXT DEFAULT 'queued',
+        progress REAL DEFAULT 0,
+        estimated_duration INTEGER,
+        payload TEXT,
+        result TEXT,
+        error TEXT,
+        logs TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        started_at DATETIME,
+        completed_at DATETIME,
+        ai_model TEXT,
+        project_path TEXT,
+        rules TEXT
+      );
+
+      CREATE TABLE IF NOT EXISTS task_dependencies (
+        task_id TEXT,
+        depends_on TEXT,
+        FOREIGN KEY (task_id) REFERENCES background_tasks(id),
+        FOREIGN KEY (depends_on) REFERENCES background_tasks(id)
+      );
+    `);
+  }
+
+  createTask(task: BackgroundTask) {
+    const stmt = this.db.prepare(`INSERT INTO background_tasks (
+      id, type, title, description, priority, status, progress, estimated_duration,
+      payload, result, error, logs, created_at, started_at, completed_at,
+      ai_model, project_path, rules
+    ) VALUES (@id, @type, @title, @description, @priority, @status, @progress, @estimatedDuration,
+      @payload, @result, @error, @logs, @createdAt, @startedAt, @completedAt,
+      @aiModel, @projectPath, @rules)`);
+    stmt.run({
+      ...task,
+      payload: JSON.stringify(task.payload ?? null),
+      result: JSON.stringify(task.result ?? null),
+      error: task.error ?? null,
+      logs: JSON.stringify(task.logs ?? []),
+      createdAt: task.createdAt.toISOString(),
+      startedAt: task.startedAt?.toISOString(),
+      completedAt: task.completedAt?.toISOString(),
+    });
+
+    // dependencies
+    const depStmt = this.db.prepare(
+      `INSERT INTO task_dependencies (task_id, depends_on) VALUES (?, ?)`,
+    );
+    for (const dep of task.dependencies) {
+      depStmt.run(task.id, dep);
+    }
+  }
+
+  getTask(id: string): BackgroundTask | null {
+    const row = this.db
+      .prepare(`SELECT * FROM background_tasks WHERE id = ?`)
+      .get(id) as any;
+    if (!row) return null;
+    return {
+      id: row.id,
+      type: row.type,
+      title: row.title,
+      description: row.description,
+      priority: row.priority,
+      status: row.status,
+      progress: row.progress,
+      estimatedDuration: row.estimated_duration,
+      dependencies: this.getDependencies(row.id),
+      payload: JSON.parse(row.payload ?? "null"),
+      result: JSON.parse(row.result ?? "null"),
+      error: row.error ?? undefined,
+      logs: JSON.parse(row.logs ?? "[]"),
+      createdAt: new Date(row.created_at),
+      startedAt: row.started_at ? new Date(row.started_at) : undefined,
+      completedAt: row.completed_at ? new Date(row.completed_at) : undefined,
+      aiModel: row.ai_model ?? "",
+      projectPath: row.project_path ?? "",
+      rules: row.rules ?? "",
+    };
+  }
+
+  updateTask(id: string, updates: Partial<BackgroundTask>) {
+    const current = this.getTask(id);
+    if (!current) return;
+    const updated = { ...current, ...updates } as BackgroundTask;
+    const stmt = this.db.prepare(`UPDATE background_tasks SET
+      type=@type,
+      title=@title,
+      description=@description,
+      priority=@priority,
+      status=@status,
+      progress=@progress,
+      estimated_duration=@estimatedDuration,
+      payload=@payload,
+      result=@result,
+      error=@error,
+      logs=@logs,
+      created_at=@createdAt,
+      started_at=@startedAt,
+      completed_at=@completedAt,
+      ai_model=@aiModel,
+      project_path=@projectPath,
+      rules=@rules
+      WHERE id=@id`);
+    stmt.run({
+      ...updated,
+      payload: JSON.stringify(updated.payload ?? null),
+      result: JSON.stringify(updated.result ?? null),
+      error: updated.error ?? null,
+      logs: JSON.stringify(updated.logs ?? []),
+      createdAt: updated.createdAt.toISOString(),
+      startedAt: updated.startedAt?.toISOString(),
+      completedAt: updated.completedAt?.toISOString(),
+    });
+  }
+
+  private getDependencies(id: string): string[] {
+    const rows = this.db
+      .prepare(`SELECT depends_on FROM task_dependencies WHERE task_id = ?`)
+      .all(id) as any[];
+    return rows.map((r) => r.depends_on);
+  }
+
+  listQueued(): BackgroundTask[] {
+    const rows = this.db
+      .prepare(
+        `SELECT id FROM background_tasks WHERE status = 'queued' ORDER BY priority ASC`,
+      )
+      .all() as any[];
+    return rows.map((r) => this.getTask(r.id)!) as BackgroundTask[];
+  }
+}

--- a/src/background/TaskManager.test.ts
+++ b/src/background/TaskManager.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { TaskDatabase } from "./TaskDatabase";
+import { TaskManager } from "./TaskManager";
+import { WorkerPool } from "./WorkerPool";
+import { BackgroundTask } from "./TaskTypes";
+import { randomUUID } from "node:crypto";
+
+function createTask(overrides: Partial<BackgroundTask> = {}): BackgroundTask {
+  return {
+    id: randomUUID(),
+    type: "code_generation",
+    title: "test",
+    description: "",
+    priority: 3,
+    status: "queued",
+    progress: 0,
+    estimatedDuration: 1,
+    dependencies: [],
+    payload: null,
+    logs: [],
+    createdAt: new Date(),
+    aiModel: "",
+    projectPath: "",
+    rules: "",
+    ...overrides,
+  };
+}
+
+describe("TaskManager", () => {
+  it("executes queued tasks", async () => {
+    const db = new TaskDatabase();
+    const pool = new WorkerPool(1);
+    const manager = new TaskManager(db, pool);
+    const task = createTask();
+    manager.addTask(task);
+
+    // wait for execution
+    await new Promise((r) => setTimeout(r, 30));
+
+    const stored = manager.getTask(task.id)!;
+    expect(stored.status).toBe("completed");
+    expect(stored.progress).toBe(100);
+  });
+});

--- a/src/background/TaskManager.ts
+++ b/src/background/TaskManager.ts
@@ -1,0 +1,62 @@
+import { EventEmitter } from "node:events";
+import { BackgroundTask, TaskStatus } from "./TaskTypes";
+import { TaskDatabase } from "./TaskDatabase";
+import { WorkerPool } from "./WorkerPool";
+
+/**
+ * TaskManager orchestrates persistence and execution of background tasks. The
+ * implementation here focuses on queueing and basic life cycle management so
+ * unit tests can exercise the scheduling logic.
+ */
+export class TaskManager extends EventEmitter {
+  constructor(
+    private db: TaskDatabase,
+    private pool: WorkerPool,
+  ) {
+    super();
+  }
+
+  /**
+   * Add a new task to the queue and persist it in the database.
+   */
+  addTask(task: BackgroundTask) {
+    this.db.createTask(task);
+    this.emit("taskQueued", task);
+    this.schedule(task);
+  }
+
+  private schedule(task: BackgroundTask) {
+    this.pool.run(async () => {
+      this.updateStatus(task.id, "running");
+      this.emit("taskStarted", task);
+      // Simulated work: in a real implementation the worker would execute
+      // different logic depending on task.type. Here we simply wait.
+      await new Promise((r) => setTimeout(r, 10));
+      this.updateStatus(task.id, "completed");
+      this.emit("taskCompleted", { ...task, status: "completed" });
+    });
+  }
+
+  private updateStatus(id: string, status: TaskStatus) {
+    const task = this.db.getTask(id);
+    if (!task) return;
+    this.db.updateTask(id, {
+      status,
+      progress: status === "completed" ? 100 : task.progress,
+      startedAt:
+        task.startedAt ?? (status === "running" ? new Date() : task.startedAt),
+      completedAt:
+        status === "completed" || status === "failed"
+          ? new Date()
+          : task.completedAt,
+    });
+  }
+
+  getTask(id: string) {
+    return this.db.getTask(id);
+  }
+
+  listQueued() {
+    return this.db.listQueued();
+  }
+}

--- a/src/background/TaskTypes.ts
+++ b/src/background/TaskTypes.ts
@@ -1,0 +1,42 @@
+export type TaskStatus =
+  | "queued"
+  | "running"
+  | "paused"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+export type TaskType =
+  | "code_generation"
+  | "app_scaffolding"
+  | "code_refactoring"
+  | "testing_suite"
+  | "build_optimization"
+  | "deployment_prep"
+  | "documentation"
+  | "code_analysis"
+  | "feature_enhancement"
+  | "bug_fixing"
+  | "full_stack_complete";
+
+export interface BackgroundTask {
+  id: string;
+  type: TaskType;
+  title: string;
+  description: string;
+  priority: 1 | 2 | 3 | 4 | 5;
+  status: TaskStatus;
+  progress: number;
+  estimatedDuration: number;
+  dependencies: string[];
+  payload: any;
+  result?: any;
+  error?: string;
+  logs: string[];
+  createdAt: Date;
+  startedAt?: Date;
+  completedAt?: Date;
+  aiModel: string;
+  projectPath: string;
+  rules: string;
+}

--- a/src/background/WorkerPool.ts
+++ b/src/background/WorkerPool.ts
@@ -1,0 +1,48 @@
+/**
+ * Minimal in-process worker pool that limits the number of concurrently
+ * running asynchronous tasks. This is a lightweight substitute for a full
+ * worker thread implementation and is sufficient for unit testing the task
+ * scheduling logic.
+ */
+export type WorkerFn<T = any> = () => Promise<T>;
+
+export class WorkerPool {
+  private queue: WorkerFn[] = [];
+  private active = 0;
+
+  constructor(private maxWorkers = 4) {}
+
+  /**
+   * Queue a task for execution. The promise resolves with the task's result
+   * once it has completed.
+   */
+  run<T>(fn: WorkerFn<T>): Promise<T> {
+    return new Promise((resolve, reject) => {
+      const task: WorkerFn = async () => {
+        try {
+          const result = await fn();
+          resolve(result as T);
+        } catch (err) {
+          reject(err);
+        } finally {
+          this.active--;
+          this.next();
+        }
+      };
+      this.queue.push(task);
+      this.next();
+    });
+  }
+
+  private next() {
+    if (this.active >= this.maxWorkers) return;
+    const task = this.queue.shift();
+    if (!task) return;
+    this.active++;
+    task();
+  }
+
+  pending() {
+    return this.queue.length + this.active;
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold background task infrastructure including TaskManager, TaskDatabase, WorkerPool, and shared task types
- add basic TaskManager test to exercise queueing and completion

## Testing
- `npm run ts`
- `npm test`
- `npm run lint` *(fails: Variable 'title' is declared but never used)*
- `npm run lint:fix` *(fails: Catch parameter 'e' is caught but never used)*
- `npm run prettier:check` *(fails: Code style issues found in 8 files)*
- `npm run pre:e2e`
- `npm run e2e` *(terminated: served HTML report, manual stop)*
- `npm run e2e:shard` *(fails: option '--shard <shard>' argument missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b070a19e2883268f3bc44a8e77f182